### PR TITLE
Adding indices on tables of local database for faster access.

### DIFF
--- a/app/src/main/java/com/connfa/model/AppDatabaseInfo.java
+++ b/app/src/main/java/com/connfa/model/AppDatabaseInfo.java
@@ -94,11 +94,16 @@ public class AppDatabaseInfo implements DBInfo, IMigrationTask {
         List<String> dbSchemaQueryList = new LinkedList<>();
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_type);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_speaker);
+        addStringWithIdToList(dbSchemaQueryList, R.string.create_table_speaker_index);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_level);
+        addStringWithIdToList(dbSchemaQueryList, R.string.create_table_level_index);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_track);
+        addStringWithIdToList(dbSchemaQueryList, R.string.create_table_track_index);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_location);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_event);
+        addStringWithIdToList(dbSchemaQueryList, R.string.create_table_event_index);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_event_and_speaker);
+        addStringWithIdToList(dbSchemaQueryList, R.string.create_table_event_and_speaker_index);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_favorite_events);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_info);
         addStringWithIdToList(dbSchemaQueryList, R.string.create_table_poi);

--- a/app/src/main/res/values/queries.xml
+++ b/app/src/main/res/values/queries.xml
@@ -31,6 +31,10 @@
         )
     </string>
 
+  <string name="create_table_speaker_index" translatable="false">
+        CREATE INDEX idx_speaker_id ON table_speaker(_id)
+    </string>
+
   <string name="create_table_level" translatable="false">
         CREATE TABLE table_level (
         _id				        INTEGER,
@@ -38,6 +42,10 @@
         _order                  DOUBLE,
         _deleted                BOOLEAN
         )
+    </string>
+
+  <string name="create_table_level_index" translatable="false">
+        CREATE INDEX idx_level_id ON table_level(_id)
     </string>
 
   <string name="create_table_track" translatable="false">
@@ -49,6 +57,10 @@
         )
     </string>
 
+  <string name="create_table_track_index" translatable="false">
+        CREATE INDEX idx_track_id ON table_track(_id)
+    </string>
+
   <string name="create_table_location" translatable="false">
         CREATE TABLE table_location (
         _id				        INTEGER,
@@ -57,6 +69,16 @@
         number				    TEXT,
         lat				        DOUBLE,
         lon				        DOUBLE,
+        _order				    DOUBLE,
+        _deleted 				BOOLEAN
+        )
+    </string>
+
+  <string name="create_table_house_plans" translatable="false">
+        CREATE TABLE table_house_plans (
+        _id				        INTEGER,
+        plan_name    			TEXT,
+        plan_image_url		    TEXT,
         _order				    DOUBLE,
         _deleted 				BOOLEAN
         )
@@ -104,11 +126,19 @@
         )
     </string>
 
+  <string name="create_table_event_index" translatable="false">
+        CREATE INDEX idx_event_event_class ON table_event(_event_class)
+    </string>
+
   <string name="create_table_event_and_speaker" translatable="false">
         CREATE TABLE table_event_and_speaker (
         _event_id		         INTEGER,
         _speaker_id			     INTEGER
         )
+    </string>
+
+  <string name="create_table_event_and_speaker_index" translatable="false">
+        CREATE INDEX index_table_event_and_speaker ON table_event_and_speaker(_event_id)
     </string>
 
   <string name="create_table_favorite_events" translatable="false">


### PR DESCRIPTION
I experienced severe performance issues when switching between the days of a multi-day conference (3 to be precise). Environment was Android 5.1.1 on an LG Nexus 4. In the debugging console there was the hint, that the sqlite database is creating an auto-index each time there is a query on the database tables. Thus, I created a manual index on the tables.