### PR TITLE
Lock the version of the io.fabric.tools to 1.27.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.27.1'
     }
 }
 


### PR DESCRIPTION
Disclaimer: I am an amateur developer when it comes to android but I think this is quite basic to get it wrong.
I disregarded all proposed updated from the latest version of AndroidStudio but in the very basic build I was getting the error 
```
ERROR: No signature of method: com.crashlytics.tools.gradle.CrashlyticsPlugin.findObfuscationTransformTask() is applicable for argument types: (java.lang.String) values: [ConnfaDebug]
```
According to https://stackoverflow.com/questions/55214993/error-no-signature-of-method-com-crashlytics-tools-gradle-crashlyticsplugin-fi there is an issue with setting the dependency as `io.fabric.tools:gradle:1.+` because the `.+` will install a version that apparently breaks it.

I applied the fix from the path above.

Also, I see the v2_dev version already has major changes since v1. Is 1 going to be abandoned? Is it redundant to provide PRs?